### PR TITLE
Update Gemfile.lock to fix shoulda matchers bundle issue due to missi…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: f800d62525a65f9bf001ea984ae4926a92ff5b82
+  revision: 4b160bd19ecca7f97d7ac22dccd5fde9b0da5a9f
   branch: rails-5
   specs:
     shoulda-matchers (3.1.2)
@@ -429,4 +429,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.6
+   1.16.1


### PR DESCRIPTION
On a fresh install of Ruby, bundle install fails on shoulda-matchers because the github commit linked is no longer there due to a rebase. See https://github.com/thoughtbot/shoulda-matchers/issues/1057